### PR TITLE
Add Nuget package signature verification

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,15 +8,11 @@ inputs:
     description: 'Additional metadata files that should be copied to the root of the deployment package. File patterns are supported, one pattern per line.'
     required: false
     default: ''
-  perform-nuget-verify:
-    description: 'A flag to indicate that the nuget signature verification step should be ran.'
-    default: 'true'
 runs:
   using: "composite"
   steps:
     - name: Verify NuGet package signatures
-      if: ${{ inputs.perform-nuget-verify == 'true' }}
-      run: dotnet nuget verify nugets/
+      run: Get-ChildItem -Recurse -File nugets -Filter *.nupkg -ErrorAction:Ignore | foreach {dotnet nuget verify $_.FullName}
       shell: pwsh
     - name: Install Octopus CLI
       uses: OctopusDeploy/install-octopus-cli-action@v1.2.1

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,16 @@ inputs:
     description: 'Additional metadata files that should be copied to the root of the deployment package. File patterns are supported, one pattern per line.'
     required: false
     default: ''
+  perform-nuget-verify:
+    description: 'A flag to indicate that the nuget signature verification step should be ran.'
+    default: 'true'
 runs:
   using: "composite"
   steps:
+    - name: Verify nuget package signatures
+      if: ${{ inputs.perform-nuget-verify == 'true' }}
+      run: dotnet nuget verify nugets/
+      shell: pwsh
     - name: Install Octopus CLI
       uses: OctopusDeploy/install-octopus-cli-action@v1.2.1
       with:

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Verify nuget package signatures
+    - name: Verify NuGet package signatures
       if: ${{ inputs.perform-nuget-verify == 'true' }}
       run: dotnet nuget verify nugets/
       shell: pwsh


### PR DESCRIPTION
Add a step to verify the digital signature on all Nuget packages under the `/nugets` folder.    This added step prevents the release process from uploading unsigned Nuget packages to Octopus Deploy.   

### Additional context
 Nuget.org will reject any packages uploaded to our feed that are not signed by the Particular signing certificate.  If a package is uploaded to Octopus Deploy and it has not been signed or has been signed with the wrong certificate, it will be rejected and the version being released will need to be burned and a new one released.

This verification step will prevent the upload to Octopus Deploy if the signature cannot be verified, which prevents the release from being burned if the signature is invalid.

