### PR TITLE
Add asset deploy verifications

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: 'Additional metadata files that should be copied to the root of the deployment package. File patterns are supported, one pattern per line.'
     required: false
     default: ''
+  perform-nuget-verify:
+    description: 'A flag to indicate that the nuget signature verification step should be ran.'
+    default: 'true'
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -11,12 +11,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Validate proper runner OS
-      if: runner.os != 'Windows' && (inputs.perform-assets-verify == 'true' || inputs.perform-deploy-verify == 'true')
-      run: |
-        echo "Asset and deploy signature verifications require Windows."
-        exit 1
-      shell: pwsh
     - name: Verify NuGet package signatures
       run: Get-ChildItem -Recurse -File nugets -Filter *.nupkg -ErrorAction:Ignore | foreach {dotnet nuget verify $_.FullName}
       shell: pwsh

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,22 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Validate proper runner OS
+      if: runner.os != 'Windows' && (inputs.perform-assets-verify == 'true' || inputs.perform-deploy-verify == 'true')
+      run: |
+        echo "Asset and deploy signature verifications require Windows."
+        exit 1
+      shell: pwsh
     - name: Verify NuGet package signatures
       run: Get-ChildItem -Recurse -File nugets -Filter *.nupkg -ErrorAction:Ignore | foreach {dotnet nuget verify $_.FullName}
+      shell: pwsh
+    - name: Verify assets signatures
+      if: runner.os == 'Windows' && inputs.perform-assets-verify == 'true'
+      run: Get-ChildItem -Recurse -File assets -Filter *.exe | foreach {&"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86\signtool.exe" verify /pa $_.FullName}
+      shell: pwsh
+    - name: Verify deploy signatures
+      if: runner.os == 'Windows' && inputs.perform-deploy-verify == 'true'
+      run: Get-ChildItem -Recurse -File deploy -Filter *.cat | foreach {&"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86\signtool.exe" verify /pa $_.FullName}
       shell: pwsh
     - name: Install Octopus CLI
       uses: OctopusDeploy/install-octopus-cli-action@v1.2.1

--- a/action.yml
+++ b/action.yml
@@ -21,12 +21,12 @@ runs:
       run: Get-ChildItem -Recurse -File nugets -Filter *.nupkg -ErrorAction:Ignore | foreach {dotnet nuget verify $_.FullName}
       shell: pwsh
     - name: Verify assets signatures
-      if: runner.os == 'Windows' && inputs.perform-assets-verify == 'true'
-      run: Get-ChildItem -Recurse -File assets -Filter *.exe | foreach {&"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86\signtool.exe" verify /pa $_.FullName}
+      if: runner.os == 'Windows'
+      run:  Get-ChildItem -Recurse -File assets -Filter *.exe -ErrorAction:Ignore | foreach {&"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86\signtool.exe" verify /pa $_.FullName}
       shell: pwsh
     - name: Verify deploy signatures
-      if: runner.os == 'Windows' && inputs.perform-deploy-verify == 'true'
-      run: Get-ChildItem -Recurse -File deploy -Filter *.cat | foreach {&"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86\signtool.exe" verify /pa $_.FullName}
+      if: runner.os == 'Windows'
+      run:  Get-ChildItem -Recurse -File assets -Filter *.cat -ErrorAction:Ignore  | foreach {&"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86\signtool.exe" verify /pa $_.FullName}
       shell: pwsh
     - name: Install Octopus CLI
       uses: OctopusDeploy/install-octopus-cli-action@v1.2.1

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,6 @@ inputs:
     description: 'Additional metadata files that should be copied to the root of the deployment package. File patterns are supported, one pattern per line.'
     required: false
     default: ''
-  perform-nuget-verify:
-    description: 'A flag to indicate that the nuget signature verification step should be ran.'
-    default: 'true'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Add steps to verify that our executables are properly signed before uploading them to Octopus Deploy.

These steps are disabled by default and can be enabled by setting the `perform-assets-verify` and the `perform-deploy-verify` flags to true when calling this action. 

### Additional context
 When an executable is run on Windows, it is checked for a valid digital signature.  If it is not properly signed,  Windows will prompt the user with a warning stating that the software could be unsafe.   

If an asset is uploaded to Octopus without being signed, then the version will need to be burned and a new version released.   By checking the signatures before we upload, we prevent the versions from being burned.  