### PR TITLE
Update the OctopusDeploy actions to v3 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           echo "Outputting all files in the packaging directory:"
           $contents = Get-ChildItem -Recurse -Path packaging | Select-Object -Property FullName
           echo $contents | Out-String -Width 1000
-          if (($contents | Measure-Object).Count -ne 6) {
+          if (($contents | Measure-Object).Count -ne 7) {
             throw "Unexpected number of files in packaging directory"
           }
 
@@ -97,7 +97,7 @@ jobs:
           echo "Outputting all files in the packaging directory:"
           $contents = Get-ChildItem -Recurse -Path packaging | Select-Object -Property FullName
           echo $contents | Out-String -Width 1000
-          if (($contents | Measure-Object).Count -ne 9) {
+          if (($contents | Measure-Object).Count -ne 10) {
             throw "Unexpected number of files in packaging directory"
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           echo "Outputting all files in the packaging directory:"
           $contents = Get-ChildItem -Recurse -Path packaging | Select-Object -Property FullName
           echo $contents | Out-String -Width 1000
+          # Directory entry, Metadata.ps1, Octopus-generated nuspec, + 2 assets & 2 nupkg
           if (($contents | Measure-Object).Count -ne 7) {
             throw "Unexpected number of files in packaging directory"
           }
@@ -97,6 +98,7 @@ jobs:
           echo "Outputting all files in the packaging directory:"
           $contents = Get-ChildItem -Recurse -Path packaging | Select-Object -Property FullName
           echo $contents | Out-String -Width 1000
+          # Same 7 previous entries + 3 new custom metadata files
           if (($contents | Measure-Object).Count -ne 10) {
             throw "Unexpected number of files in packaging directory"
           }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Before this action runs:
 ```yaml
     steps:
       - name: Deploy
-        uses: Particular/push-octopus-package-action@v1.0.0
+        uses: Particular/push-octopus-package-action@v2.0.0
         with:
           octopus-deploy-api-key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}
 ```
@@ -32,7 +32,7 @@ This is used primarily for [ServiceControl](https://github.com/Particular/Servic
 ```yaml
     steps:
       - name: Deploy
-        uses: Particular/push-octopus-package-action@v1.0.0
+        uses: Particular/push-octopus-package-action@v2.0.0
         with:
           octopus-deploy-api-key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}
           additional-metadata-paths: metadata/*.json
@@ -42,7 +42,7 @@ This is used primarily for [ServiceControl](https://github.com/Particular/Servic
 ```yaml
     steps:
       - name: Deploy
-        uses: Particular/push-octopus-package-action@v1.0.0
+        uses: Particular/push-octopus-package-action@v2.0.0
         with:
           octopus-deploy-api-key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}
           additional-metadata-paths: |
@@ -54,7 +54,6 @@ This is used primarily for [ServiceControl](https://github.com/Particular/Servic
 
 This action abstracts the following steps:
 
-1. Installing the Octopus CLI
 1. Arranging NuGet packages and other assets on disk for packaging
 1. Creating a metadata file to pass version information to Octopus Deploy
 1. Packaging the content into a RepoName.Deploy package

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
       run:  Get-ChildItem -Recurse -File deploy -Filter *.cat -ErrorAction:Ignore  | foreach {& "$($Env:SIGNTOOL)" verify /pa $_.FullName}
       shell: pwsh
     - name: Install Octopus CLI
-      uses: OctopusDeploy/install-octopus-cli-action@v1.2.1
+      uses: OctopusDeploy/install-octopus-cli-action@v3.1.1
       with:
         version: latest
     - name: Create Octopus Package
@@ -101,7 +101,7 @@ runs:
         }
 
         # Create the Octopus package
-        octo pack --id="$($RepoName).Deploy" --version="${{env.MinVerVersion}}" --format="nupkg" --basePath="packaging" --outFolder="octopus-package"
+        octopus pack --id="$($RepoName).Deploy" --version="${{env.MinVerVersion}}" --format="nupkg" --basePath="packaging" --outFolder="octopus-package"
       shell: pwsh
     - name: Publish Octopus Package Artifacts
       uses: actions/upload-artifact@v3.1.3

--- a/action.yml
+++ b/action.yml
@@ -37,10 +37,6 @@ runs:
       if: runner.os == 'Windows'
       run:  Get-ChildItem -Recurse -File deploy -Filter *.cat -ErrorAction:Ignore  | foreach {& "$($Env:SIGNTOOL)" verify /pa $_.FullName}
       shell: pwsh
-  #  - name: Install Octopus CLI
-   #   uses: OctopusDeploy/install-octopus-cli-action@v3.1.1
-    #  with:
-     #   version: latest
     - name: Create the files
       env:
         ADDITIONAL_METADATA_PATHS: ${{ inputs.additional-metadata-paths }}
@@ -99,10 +95,6 @@ runs:
             Copy-Item $_ packaging
           }
         }
-        # Login into our server
-        #octopus login --server="https://deploy.particular.net" --api-key="${{inputs.octopus-deploy-api-key}}"
-        # Create the Octopus package
-        #octopus package nuget create --id="$($RepoName).Deploy" --version="${{env.MinVerVersion}}" --base-path="packaging" --out-folder="octopus-package" --verbose
       shell: pwsh
     - name: Create a NuGet package
       id: package

--- a/action.yml
+++ b/action.yml
@@ -127,6 +127,7 @@ runs:
         server: https://deploy.particular.net
         api_key: ${{ inputs.octopus-deploy-api-key }}
         packages: octopus-package/${{env.PARTICULAR_REPO_NAME}}.Deploy.${{env.MinVerVersion}}.nupkg
+        space: particular
     - name: Create Octopus Deploy release
       uses: OctopusDeploy/create-release-action@v3.2.1
       with:
@@ -136,3 +137,4 @@ runs:
         release_number: ${{env.MinVerVersion}}
         package_version: ${{env.MinVerVersion}}
         packages: "GitReleaseManager:0.11.0"
+        space: particular

--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,7 @@ runs:
         # Login into our server
         octopus login --server="https://deploy.particular.net" --api-key="${{inputs.octopus-deploy-api-key}}"
         # Create the Octopus package
-        octopus package nuget create --id="$($RepoName).Deploy" --version="${{env.MinVerVersion}}" --base-path="packaging" --out-folder="octopus-package"
+        octopus package nuget create --id="$($RepoName).Deploy" --version="${{env.MinVerVersion}}" --base-path="packaging" --out-folder="octopus-package" --verbose
       shell: pwsh
     - name: Publish Octopus Package Artifacts
       uses: actions/upload-artifact@v3.1.3

--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,7 @@ runs:
         # Login into our server
         octopus login --server="https://deploy.particular.net" --api-key="${{inputs.octopus-deploy-api-key}}"
         # Create the Octopus package
-        octopus pack --id="$($RepoName).Deploy" --version="${{env.MinVerVersion}}" --format="nupkg" --basePath="packaging" --outFolder="octopus-package"
+        octopus package nuget create --id="$($RepoName).Deploy" --version="${{env.MinVerVersion}}" --base-path="packaging" --out-folder="octopus-package"
       shell: pwsh
     - name: Publish Octopus Package Artifacts
       uses: actions/upload-artifact@v3.1.3

--- a/action.yml
+++ b/action.yml
@@ -109,7 +109,7 @@ runs:
         nuspec_description: Deployment package for ${{env.PARTICULAR_REPO_NAME}} - not for nuget.org
         nuspec_authors: Particular Software
     - name: Publish Octopus Package Artifacts
-      uses: actions/upload-artifact@v3.1.3
+      uses: actions/upload-artifact@v4.3.1
       with:
         name: ${{steps.package.outputs.package_filename}}
         path: ${{steps.package.outputs.package_file_path}}

--- a/action.yml
+++ b/action.yml
@@ -105,6 +105,7 @@ runs:
         #octopus package nuget create --id="$($RepoName).Deploy" --version="${{env.MinVerVersion}}" --base-path="packaging" --out-folder="octopus-package" --verbose
       shell: pwsh
     - name: Create a NuGet package
+      id: package
       uses: OctopusDeploy/create-nuget-package-action@v3.1.1
       with:
         package_id: ${{env.PARTICULAR_REPO_NAME}}
@@ -118,15 +119,15 @@ runs:
     - name: Publish Octopus Package Artifacts
       uses: actions/upload-artifact@v3.1.3
       with:
-        name: octopus-package
-        path: octopus-package/*
+        name: ${{steps.package.outputs.package_filename}}
+        path: ${{steps.package.outputs.package_file_path}}
         retention-days: 1
     - name: Push package to Octopus Deploy
       uses: OctopusDeploy/push-package-action@v3.2.1
       with:
         server: https://deploy.particular.net
         api_key: ${{ inputs.octopus-deploy-api-key }}
-        packages: octopus-package/${{env.PARTICULAR_REPO_NAME}}.Deploy.${{env.MinVerVersion}}.nupkg
+        packages: ${{steps.package.outputs.package_file_path}}
         space: "Default"
     - name: Create Octopus Deploy release
       uses: OctopusDeploy/create-release-action@v3.2.1

--- a/action.yml
+++ b/action.yml
@@ -107,12 +107,14 @@ runs:
     - name: Create a NuGet package
       uses: OctopusDeploy/create-nuget-package-action@v3.1.1
       with:
-        package_id: '${{env.PARTICULAR_REPO_NAME}}'
-        version: '${{env.MinVerVersion}}'
-        output_folder: 'octopus-package'
+        package_id: ${{env.PARTICULAR_REPO_NAME}}
+        version: ${{env.MinVerVersion}}
+        output_folder: octopus-package
         base_path: packaging
         files: |
-        **/*.*
+          **/*.*
+        nuspec_description: This is a real description
+        nuspec_authors: Particular software
     - name: Publish Octopus Package Artifacts
       uses: actions/upload-artifact@v3.1.3
       with:

--- a/action.yml
+++ b/action.yml
@@ -96,7 +96,7 @@ runs:
           }
         }
       shell: pwsh
-    - name: Create a NuGet package
+    - name: Create an Octopus NuGet deployment package
       id: package
       uses: OctopusDeploy/create-nuget-package-action@v3.1.1
       with:
@@ -106,8 +106,8 @@ runs:
         base_path: packaging
         files: |
           **/*.*
-        nuspec_description: This is a real description
-        nuspec_authors: Particular software
+        nuspec_description: Deployment package for ${{env.PARTICULAR_REPO_NAME}} - not for nuget.org
+        nuspec_authors: Particular Software
     - name: Publish Octopus Package Artifacts
       uses: actions/upload-artifact@v3.1.3
       with:

--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
       id: package
       uses: OctopusDeploy/create-nuget-package-action@v3.1.1
       with:
-        package_id: ${{env.PARTICULAR_REPO_NAME}}
+        package_id: ${{env.PARTICULAR_REPO_NAME}}.Deploy
         version: ${{env.MinVerVersion}}
         output_folder: octopus-package
         base_path: packaging

--- a/action.yml
+++ b/action.yml
@@ -99,7 +99,8 @@ runs:
             Copy-Item $_ packaging
           }
         }
-
+        # Login into our server
+         octopus login --server {https://deploy.particular.net} --api-key {inputs.octopus-deploy-api-key}
         # Create the Octopus package
         octopus pack --id="$($RepoName).Deploy" --version="${{env.MinVerVersion}}" --format="nupkg" --basePath="packaging" --outFolder="octopus-package"
       shell: pwsh

--- a/action.yml
+++ b/action.yml
@@ -127,7 +127,7 @@ runs:
         server: https://deploy.particular.net
         api_key: ${{ inputs.octopus-deploy-api-key }}
         packages: octopus-package/${{env.PARTICULAR_REPO_NAME}}.Deploy.${{env.MinVerVersion}}.nupkg
-        space: particular
+        space: "Default"
     - name: Create Octopus Deploy release
       uses: OctopusDeploy/create-release-action@v3.2.1
       with:
@@ -137,4 +137,4 @@ runs:
         release_number: ${{env.MinVerVersion}}
         package_version: ${{env.MinVerVersion}}
         packages: "GitReleaseManager:0.11.0"
-        space: particular
+        space: "Default"

--- a/action.yml
+++ b/action.yml
@@ -37,11 +37,11 @@ runs:
       if: runner.os == 'Windows'
       run:  Get-ChildItem -Recurse -File deploy -Filter *.cat -ErrorAction:Ignore  | foreach {& "$($Env:SIGNTOOL)" verify /pa $_.FullName}
       shell: pwsh
-    - name: Install Octopus CLI
-      uses: OctopusDeploy/install-octopus-cli-action@v3.1.1
-      with:
-        version: latest
-    - name: Create Octopus Package
+  #  - name: Install Octopus CLI
+   #   uses: OctopusDeploy/install-octopus-cli-action@v3.1.1
+    #  with:
+     #   version: latest
+    - name: Create the files
       env:
         ADDITIONAL_METADATA_PATHS: ${{ inputs.additional-metadata-paths }}
       run: |
@@ -100,10 +100,19 @@ runs:
           }
         }
         # Login into our server
-        octopus login --server="https://deploy.particular.net" --api-key="${{inputs.octopus-deploy-api-key}}"
+        #octopus login --server="https://deploy.particular.net" --api-key="${{inputs.octopus-deploy-api-key}}"
         # Create the Octopus package
-        octopus package nuget create --id="$($RepoName).Deploy" --version="${{env.MinVerVersion}}" --base-path="packaging" --out-folder="octopus-package" --verbose
+        #octopus package nuget create --id="$($RepoName).Deploy" --version="${{env.MinVerVersion}}" --base-path="packaging" --out-folder="octopus-package" --verbose
       shell: pwsh
+    - name: Create a NuGet package
+      uses: OctopusDeploy/create-nuget-package-action@v3.1.1
+      with:
+        package_id: '${{env.PARTICULAR_REPO_NAME}}'
+        version: '${{env.MinVerVersion}}'
+        output_folder: 'octopus-package'
+        base_path: packaging
+        files: |
+        **/*.*
     - name: Publish Octopus Package Artifacts
       uses: actions/upload-artifact@v3.1.3
       with:

--- a/action.yml
+++ b/action.yml
@@ -122,13 +122,13 @@ runs:
         path: octopus-package/*
         retention-days: 1
     - name: Push package to Octopus Deploy
-      uses: OctopusDeploy/push-package-action@v2.2.0
+      uses: OctopusDeploy/push-package-action@v3.2.1
       with:
         server: https://deploy.particular.net
         api_key: ${{ inputs.octopus-deploy-api-key }}
         packages: octopus-package/${{env.PARTICULAR_REPO_NAME}}.Deploy.${{env.MinVerVersion}}.nupkg
     - name: Create Octopus Deploy release
-      uses: OctopusDeploy/create-release-action@v2.1.0
+      uses: OctopusDeploy/create-release-action@v3.2.1
       with:
         server: https://deploy.particular.net
         api_key: ${{ inputs.octopus-deploy-api-key }}

--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
           }
         }
         # Login into our server
-         octopus login --server {https://deploy.particular.net} --api-key {inputs.octopus-deploy-api-key}
+        octopus login --server="https://deploy.particular.net" --api-key="${{inputs.octopus-deploy-api-key}}"
         # Create the Octopus package
         octopus pack --id="$($RepoName).Deploy" --version="${{env.MinVerVersion}}" --format="nupkg" --basePath="packaging" --outFolder="octopus-package"
       shell: pwsh


### PR DESCRIPTION
Updates the version of OctopusDeploy/install-octupus-cli-action from [1.2.1 to 3.1.1](https://github.com/OctopusDeploy/install-octopus-cli-action/blob/main/migration-guide.md), which needs to use the 'octopus' command instead of 'octo'.
I'm doing some research around this because the parity of the commands is not evident. I was able to find this [statement](https://github.com/OctopusDeploy/cli/blob/main/README.md#overview) on their docs:
> This project aims to create a new CLI (written in Go) for communicating with the Octopus Deploy Server.
> It does not seek to be a drop-in replacement for the existing CLI which is written in C# using .NET.

This PR will replaces the [PR opened by Dependabot](https://github.com/Particular/push-octopus-package-action/pull/49).

**Edit to update:** The Octopus team changed the way their actions work, so now we [don't need to install the octopus CLI](https://octopus.com/blog/github-actions-for-octopus-deploy-v3#octopus-cli-is-no-longer-required) to create packages and upload them. That blog post was also my guide to migrate the actions to v3.